### PR TITLE
Remove directed search from Search Interface

### DIFF
--- a/client/stylesheets/style.css
+++ b/client/stylesheets/style.css
@@ -251,11 +251,10 @@ body {
 	grid-area: bottomcontent;
 }
 
-
 .wrapper {
 	display: grid;
 	grid-gap: 10px;
-	grid-template-columns: 620px 1580px;
+	grid-template-columns: 320px 1580px;
 	grid-template-rows: 1fr 1fr;
 	grid-template-areas:
 	"sidebar topcontent"
@@ -276,20 +275,6 @@ body {
 	padding: 10px;
 	font-size: 150%;
 }
-
-/* search results grid styles */
-.search-results-wrapper {
-	display: grid;
-	grid-template-columns: 0.9fr 1.1fr;
-	grid-gap: 10px;
-}
-
-.lego-search-results {
-	grid-area: lego-search-results;
-}
-
-/* construct legos grid styles */
-
 
 .remove-category .btn-panel-item {
 	padding: 0px 6px;

--- a/client/templates/feature_discovery.html
+++ b/client/templates/feature_discovery.html
@@ -2,19 +2,8 @@
   <div class="panel panel-default">
     {{> searchBar}}
   </div>
-  <div class="search-results-wrapper">
-
-    <div class="panel panel-default left-search">
-      <div class="panel-heading">
-        Search by Matching Strings
-      </div>
-      <ul class="list-group">
-        {{#each directedSearchResults}}
-          {{> directedSearchResultItem}}
-        {{/each}}
-      </ul>
-    </div>
-    <div class="panel panel-default right-search">
+  <div>
+    <div class="panel panel-default">
       <div class="panel-heading">
         Yelp Categories you can find "{{searchInputText}}"
         <button id="convert-button" type="button" class="btn btn-small btn-primary">Combine Categories</button>
@@ -32,8 +21,6 @@
     </div>
   </div>
 
-  <!-- {{> blockSearchResults}} -->
-  <!-- {{> searchResults}} -->
 </template>
 
 <template name="searchBar">
@@ -48,23 +35,6 @@
       </span>
     </div>
   </form>
-</template>
-
-<template name="searchResults">
-  <div class="search-result-wrapper">
-    <div class="box">One</div>
-    <div class="box">Two</div>
-    <div class="box">Three</div>
-  </div>
-</template>
-
-<template name="directedSearchResultItem">
-  <li href="#" class="list-group-item" detectorDescription="{{description}}" detectorId="{{_id}}">
-    {{description}}
-    <button type="button" class="btn-use-block btn btn-primary btn-sm pull-right btn-panel-item">
-      <span class="glyphicon glyphicon-plus"  aria-hidden="true"></span>
-    </button>
-  </li>
 </template>
 
 <template name="stretchSearchResultItem">

--- a/client/templates/feature_discovery.js
+++ b/client/templates/feature_discovery.js
@@ -68,24 +68,6 @@ Template.featureDiscovery.helpers({
     obj = Queries.findOne(queryId);
     return (obj.categories.length - obj.excluded_categories.length) / obj.categories.length
   },
-
-  'directedSearchResults': function() {
-    if (Session.get("searchInputText")) {
-      Meteor.subscribe("blockSearch", Session.get("searchInputText"));
-
-      // We cannot re-use the query as MiniMongo does not support the $text operator!
-      // Instead of resorting to a Meteor method we can hack around it by relying on an extra
-      // ad-hoc collection containing the sorted ids ...
-      const key = JSON.stringify(Session.get("searchInputText"));
-      const result = Detectors.BlockSearchResults.findOne(key);
-      if (result) {
-        const idsInSortOrder = result.results;
-        const blocksInSortedOrder = idsInSortOrder.map(id => Detectors.findOne(id));
-        return blocksInSortedOrder;
-      }
-    }
-  }
-
 });
 
 if (Meteor.isServer) {


### PR DESCRIPTION
Summary: Removed the directed search (which used simple string matching
on the category name). This was motivated for two reasons

1. During user testing, many people ignored this column
2. Directed Search was based on Yelp Category Titles.  While we use
aliases for the feature-name UI, we will ignore this to make sure only
aliases are used.

Test: No longer in the UI